### PR TITLE
Fix destroy() for typeorm-0.2.

### DIFF
--- a/src/app/TypeormStore/TypeormStore.ts
+++ b/src/app/TypeormStore/TypeormStore.ts
@@ -103,7 +103,7 @@ export class TypeormStore extends Store {
   public destroy = (sid: string | string[], fn: (error?: any) => void) => {
     this.debug('DEL "%s"', sid);
 
-    Promise.all((Array.isArray(sid) ? sid : [sid]).map((x) => this.repository.deleteById(x)))
+    Promise.all((Array.isArray(sid) ? sid : [sid]).map((x) => this.repository.delete({ id: x })))
       .then(() => {
         fn();
       })


### PR DESCRIPTION
typeorm-0.2 removes Repository.deleteById(). typeorm-0.1 and
typeorm-0.2 both have Repository.delete(), so this change switches to
use that method instead and while keeping compatibility with
typeorm-0.1.

Fixes #1.

I haven’t tested this properly yet.