### PR TITLE
Make touch to be an instance property

### DIFF
--- a/src/app/TypeormStore/TypeormStore.ts
+++ b/src/app/TypeormStore/TypeormStore.ts
@@ -116,7 +116,7 @@ export class TypeormStore extends Store {
   /**
    * Refreshes the time-to-live for the session with the given `sid`.
    */
-  public touch(sid: string, sess: any, fn: (error?: any) => void) {
+  public touch = (sid: string, sess: any, fn: (error?: any) => void) => {
     const ttl = this.getTTL(sess);
 
     this.debug('EXPIRE "%s" ttl:%s', sid, ttl);


### PR DESCRIPTION
Since `Store` defines `touch` as an instance property, typescript throws on this:

```
node_modules/connect-typeorm/out/app/TypeormStore/TypeormStore.d.ts:38:5 - error TS2425: Class 'Store' defines instance member property 'touch', but extended class 'TypeormStore' defines it as instance member function.
```